### PR TITLE
Allow cluster personalization condition to use a comparison operator

### DIFF
--- a/DemoCortex/src/Foundation/ProcessingEngine/code/Conditionals/PersonalizeCluster.cs
+++ b/DemoCortex/src/Foundation/ProcessingEngine/code/Conditionals/PersonalizeCluster.cs
@@ -6,10 +6,8 @@ using Sitecore.Rules.Conditions;
 
 namespace Demo.Foundation.ProcessingEngine.Conditionals
 {
-    public class PersonalizeCluster<T> : StringOperatorCondition<T> where T : RuleContext
+    public class PersonalizeCluster<T> : IntegerComparisonCondition<T> where T : RuleContext
     {
-        public int Number { get; set; }
-
         protected override bool Execute(T ruleContext)
         {
             if (!Tracker.Current.IsActive || Tracker.Current.Contact == null) return false;
@@ -19,7 +17,7 @@ namespace Demo.Foundation.ProcessingEngine.Conditionals
 
             if (!(xConnectFacets.Facets[RfmContactFacet.DefaultFacetKey] is RfmContactFacet facet)) return false;
 
-            return facet.Cluster == Number;
+            return Compare(facet.Cluster);
         }
     }
 }


### PR DESCRIPTION
**Problem:** The cluster personalization condition is hardcoded to a "is equal to" (`==`) comparison in the code. Additionally, its Sitecore item type is not the right class. It is "ClusterMatch". It should be "PersonalizeCluster".

**Solution:** Change the code interface, remove its custom property, and use the built-in `Compare` method.

**Additional changes to apply:**

1. Change the "Text" field value on the "/sitecore/system/Settings/Rules/Definitions/Elements/Demo Personalization/Where Contact is in Cluster" item to "where the contact cluster [operatorid,Operator,,compares to] [value,,,value]"
2. Change the "Type" field value on the same item to "Demo.Foundation.ProcessingEngine.Conditionals.PersonalizeCluster, Demo.Foundation.ProcessingEngine".